### PR TITLE
Anime text wrap bug

### DIFF
--- a/src/css/global.js
+++ b/src/css/global.js
@@ -1049,6 +1049,7 @@ button {
   padding: .5em;
   overflow-x: hidden;
   overflow-y: scroll;
+  overflow-wrap: anywhere;
 }
 
 .episode-link {

--- a/src/css/global.js
+++ b/src/css/global.js
@@ -1052,6 +1052,10 @@ button {
   overflow-wrap: anywhere;
 }
 
+.episode-link::first-letter {
+  text-transform:  capitalize;
+}
+
 .episode-link {
   line-height: 1.3em;
   font-size: .9em;


### PR DESCRIPTION
Anime container overflows due to the episode's link not wrapping based on its parent container.

- fixed the wrapper :)

- capitalize the first letter of all anime episode link.