### PR TITLE
:hammer: Code of Conduct solecism on attribution section

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -68,5 +68,5 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from theContribution Convenant
+This Code of Conduct is adapted from the Contribution Convenant
 available at [Contributor Convenant](http://contributor-covenant.org/version/1/4)


### PR DESCRIPTION
 This PR fixes #142  

Changed _This Code of Conduct is adapted from #theContribution Convenant
available at [Contributor Convenant](http://contributor-covenant.org/version/1/4)_ to **This Code of Conduct is adapted from the Contribution Convenant
available at [Contributor Convenant](http://contributor-covenant.org/version/1/4)**